### PR TITLE
E4

### DIFF
--- a/template/vgs2.h
+++ b/template/vgs2.h
@@ -98,6 +98,8 @@ void eff_flag(struct _EFF* e,unsigned int f);
 void eff_pos(struct _EFF* e,unsigned int f);
 void lock();
 void unlock();
+void lock2();
+void unlock2();
 void make_pallet();
 int gload(unsigned char n,const char* name);
 int eload(unsigned char n,const char* name);


### PR DESCRIPTION
OpenSL/ESの解放手順を修正。
プレイ状態をSL_PLAYSTATE_STOPPEDに変更する前にBufferQueueのクリアをしなければ、一部の端末でクラッシュするらしい。
