### PR TITLE
E5: E4の対策をより安全にする

### DIFF
--- a/template/vgs2a.c
+++ b/template/vgs2a.c
@@ -3,8 +3,8 @@
  * Description: GameDaddy - emulator
  *    Platform: Android
  *      Author: Yoji Suzuki (SUZUKI PLAN)
- *        Date: 7-Sept-2014
- * FileVersion: 1.03
+ *        Date: 27-Sept-2014
+ * FileVersion: 1.05
  *----------------------------------------------------------------------------
  */
 #include <pthread.h>


### PR DESCRIPTION
先日E4のPRで対策した件に修正不十分があったので対策。
仮にコールバックが実行中且つmutexロック前のタイミングでterm処理が行われた場合、Buffer QueueをClearした後にEnqueueが呼び出されることで、結果的にキューイングがされた状態でOpenSL/ESプレイヤの解放を行う可能性があるので、必ずしも安全とは断言できないと考えられます。
Enqueueでプレイ状態がSTOPPEDだから抑止されるようであれば安全で、恐らくOpenSL/ESの実装上はそうなっている可能性が高いと考えられますが、コントロール可能な範囲で安全策を実施しておいた方が良いと考えられます。
ただし、この修正単体でのバージョンアップの必要性は無いという認識です。
その辺りのことはANRレポートがまた来た時に考えれば良いと思います。
ついでに、E4でファイルバージョンの更新が漏れていたので更新。GitHubを使っているのだから、もはやファイルバージョンは何の意味も為さないと思いきや、VGS2本体以外はローカルで管理している関係で、ファイうバージョンは割と重要だったりします。（プライベートリポジトリを持てれば全て解決ですが...）
