### PR TITLE
vgs2play command (note: Linux and Mac OS X only)

### DIFF
--- a/bin_src/makefile
+++ b/bin_src/makefile
@@ -1,6 +1,9 @@
 all:
 	make all-`uname`
 
+all-Linux:
+	make allcom SOUNDLIB=-lasound
+
 all-Darwin:
 	make allcom SOUNDLIB="-framework OpenAL"
 
@@ -31,5 +34,5 @@ allcom: ../bin\
 	gcc -o ../bin/vgs2wav vgs2wav.c
 
 ../bin/vgs2play: vgs2play.c
-	gcc -o ../bin/vgs2play -I../template vgs2play.c ../template/vgs2api.c ../template/vgs2tone.c $(SOUNDLIB)
+	gcc -o ../bin/vgs2play -I../template vgs2play.c ../template/vgs2api.c ../template/vgs2tone.c $(SOUNDLIB) -lpthread
 

--- a/bin_src/makefile
+++ b/bin_src/makefile
@@ -1,9 +1,16 @@
-all: ../bin\
+all:
+	make all-`uname`
+
+all-Darwin:
+	make allcom SOUNDLIB="-framework OpenAL"
+
+allcom: ../bin\
 	../bin/vgs2bmp\
 	../bin/vgs2mkpj\
 	../bin/vgs2mml\
 	../bin/vgs2rom\
-	../bin/vgs2wav
+	../bin/vgs2wav\
+	../bin/vgs2play
 
 ../bin:
 	mkdir ../bin
@@ -22,4 +29,7 @@ all: ../bin\
 
 ../bin/vgs2wav: vgs2wav.c
 	gcc -o ../bin/vgs2wav vgs2wav.c
+
+../bin/vgs2play: vgs2play.c
+	gcc -o ../bin/vgs2play -I../template vgs2play.c ../template/vgs2api.c ../template/vgs2tone.c $(SOUNDLIB)
 

--- a/bin_src/vgs2play.c
+++ b/bin_src/vgs2play.c
@@ -215,10 +215,9 @@ int main(int argc,char* argv[])
     /* terminate procedure */
     STALIVE=0;
     pthread_join(tid,NULL);
-#if defined(__linux)
+#if defined(__APPLE__)
     alcDestroyContext(sndCtx);
     alcCloseDevice(sndDev);
-#elif defined(__APPLE__)
 #endif
     
     return 0;

--- a/bin_src/vgs2play.c
+++ b/bin_src/vgs2play.c
@@ -1,0 +1,278 @@
+/* VGS BGM player cli */
+#include <pthread.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/timeb.h>
+#include <stdio.h>
+#include <time.h>
+#include "vgs2.h"
+
+int bload_direct(unsigned char n,const char* name);
+
+/* include os depended header files */
+#if defined(__linux)
+#   include <alsa/asoundlib.h>
+#elif defined(__APPLE__)
+#   include <OpenAL/al.h>
+#   include <OpenAL/alc.h>
+#   define kOutputBus 0
+#   define kInputBus 1
+#   define BUFNUM 2
+#   undef SAMPLE_BITS
+#   define SAMPLE_BITS	AL_FORMAT_MONO16	/* redefine sampling bits */
+static ALCdevice* sndDev;
+static ALCcontext* sndCtx;
+static ALuint sndABuf;
+static ALuint sndASrc;
+static char SBUF[SAMPLE_BUFS];
+typedef ALvoid AL_APIENTRY (*alBufferDataStaticProcPtr) (const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq);
+static alBufferDataStaticProcPtr alBufferDataStaticProc;
+#else
+#   error "Not supported platform."
+#endif
+
+/* platform common data */
+static unsigned short ADPAL[256];
+static pthread_mutex_t LCKOBJ=PTHREAD_MUTEX_INITIALIZER;
+static int REQ;
+static int STALIVE=1;
+
+/**
+ * initialize sound system
+ */
+static int sound_init()
+{
+#if defined(__linux)
+    return 0;
+#elif defined(__APPLE__)
+    sndDev=alcOpenDevice(NULL);
+    if(NULL==sndDev) {
+        return -1;
+    }
+    sndCtx=alcCreateContext(sndDev, NULL);
+    if(NULL==sndCtx) {
+        return -1;
+    }
+    if(!alcMakeContextCurrent(sndCtx)) {
+        return -1;
+    }
+    alBufferDataStaticProc=(alBufferDataStaticProcPtr)alcGetProcAddress(NULL,(const ALCchar *)"alBufferDataStatic");
+    return 0;
+#endif
+}
+
+/**
+ * sound thread procedure
+ */
+static void* sound_thread(void* args)
+{
+#if defined(__linux)
+    int i;
+    snd_pcm_t* snd;
+    snd_pcm_hw_params_t* hwp;
+    int rate=SAMPLE_RATE;
+    int periods=3;
+    short buf[SAMPLE_BUFS/2];
+    snd_pcm_hw_params_alloca(&hwp);
+    i=snd_pcm_open(&snd,"default",SND_PCM_STREAM_PLAYBACK,0);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_open error: %d\n",i);
+        return NULL;
+    }
+    i=snd_pcm_hw_params_any(snd,hwp);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params_any error: %d\n",i);
+        return NULL;
+    }
+    i=snd_pcm_hw_params_set_format(snd,hwp,SND_PCM_FORMAT_S16_LE);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params_set_format error: %d\n",i);
+        return NULL;
+    }
+    i=snd_pcm_hw_params_set_rate_near(snd,hwp,&rate,0);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params_set_rate_near error: %d\n",i);
+        return NULL;
+    }
+    if(rate!=SAMPLE_RATE) {
+        fprintf(stderr,"This sound hawdware does not supports %dHz mode.\n",SAMPLE_RATE);
+        return NULL;
+    }
+    i=snd_pcm_hw_params_set_channels(snd,hwp,SAMPLE_CH);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params_set_channels error: %d\n",i);
+        return NULL;
+    }
+    i=snd_pcm_hw_params_set_periods(snd,hwp,periods,0);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params_set_periods error: %d\n",i);
+        return NULL;
+    }
+    i=snd_pcm_hw_params_set_buffer_size(snd,hwp,(periods*sizeof(buf))/4);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params_set_buffer_size error: %d\n",i);
+        return NULL;
+    }
+    i=snd_pcm_hw_params(snd,hwp);
+    if(i<0) {
+        fprintf(stderr,"snd_pcm_hw_params error: %d\n",i);
+        return NULL;
+    }
+    while(STALIVE) {
+        sndbuf((char*)buf,sizeof(buf));
+        while(STALIVE) {
+            i=snd_pcm_writei(snd,buf,sizeof(buf)/2);
+            if(i<0) {
+                snd_pcm_prepare(snd);
+                puts("Buffer underrun");
+            } else {
+                break;
+            }
+        }
+    }
+    snd_pcm_drain(snd);
+    snd_pcm_close(snd);
+    return NULL;
+#elif defined(__APPLE__)
+    ALint st;
+    alGenSources(1,&sndASrc);
+    memset(SBUF,0,SAMPLE_BUFS);
+    while(STALIVE) {
+        alGetSourcei(sndASrc, AL_BUFFERS_QUEUED, &st);
+        if (st < BUFNUM) {
+            alGenBuffers(1, &sndABuf);
+        } else {
+            alGetSourcei(sndASrc, AL_SOURCE_STATE, &st);
+            if (st != AL_PLAYING) {
+                alSourcePlay(sndASrc);
+            }
+            while (alGetSourcei(sndASrc, AL_BUFFERS_PROCESSED, &st), st == 0) {
+                usleep(1000);
+            }
+            alSourceUnqueueBuffers(sndASrc, 1, &sndABuf);
+            alDeleteBuffers(1,&sndABuf);
+            alGenBuffers(1, &sndABuf);
+        }
+        sndbuf(SBUF,SAMPLE_BUFS);
+        alBufferData(sndABuf,SAMPLE_BITS,SBUF,SAMPLE_BUFS,SAMPLE_RATE);
+        alSourceQueueBuffers(sndASrc, 1, &sndABuf);
+    }
+    return NULL;
+#endif
+}
+
+/**
+ * main procedure
+ */
+int main(int argc,char* argv[])
+{
+    pthread_t tid;
+    struct sched_param param;
+    char buf[1024];
+
+    /* check argument */
+    if(argc<2) {
+        puts("usage: vgs2play bgm-file");
+        return 1;
+    }
+
+    /* intialize sound system */
+    if(sound_init()) {
+        fprintf(stderr,"Could not initialize the sound system.¥n");
+        return 2;
+    }
+    if(0!=pthread_create(&tid,NULL,sound_thread,NULL)) {
+        fprintf(stderr,"Could not create the sound thread.\n");
+        return 2;
+    }
+    memset(&param,0,sizeof(param));
+    param.sched_priority = 46;
+    pthread_setschedparam(tid,SCHED_OTHER,&param);
+
+    /* load BGM data and play */
+    if(bload_direct(0,argv[1])) {
+        fprintf(stderr,"Load error.\n");
+        return 2;
+    }
+	vgs2_bplay(0);
+
+    /* show reference */
+    puts("Command Reference:");
+    puts("- q : quit playing");
+    puts("");
+
+    /* main loop */
+    memset(buf,0,sizeof(buf));
+    printf("command: ");
+    while(NULL!=fgets(buf,sizeof(buf)-1,stdin)) {
+        if(buf[0]=='q') {
+            break;
+        }
+        memset(buf,0,sizeof(buf));
+        printf("command: ");
+    }
+
+    /* terminate procedure */
+    STALIVE=0;
+    pthread_join(tid,NULL);
+#if defined(__linux)
+    alcDestroyContext(sndCtx);
+    alcCloseDevice(sndDev);
+#elif defined(__APPLE__)
+#endif
+    
+    return 0;
+}
+
+void putlog(const char* fn,int ln,const char* msg,...)
+{
+    va_list args;
+    time_t t1;
+    struct tm* t2;
+    struct timeb tb;
+    char buf[1024];
+    
+    ftime(&tb);
+    t1=tb.time;
+    t2=localtime(&t1);
+    sprintf(buf,"%04d/%02d/%02d %02d:%02d:%02d.%03d "
+            ,t2->tm_year+1900
+            ,t2->tm_mon+1
+            ,t2->tm_mday
+            ,t2->tm_hour
+            ,t2->tm_min
+            ,t2->tm_sec
+            ,tb.millitm
+            );
+    va_start(args,msg);
+    vsprintf(buf+strlen(buf),msg,args);
+    va_end(args);
+    fprintf(stderr,"%s",buf);
+}
+
+void lock()
+{
+    pthread_mutex_lock(&LCKOBJ);
+}
+
+void unlock()
+{
+    pthread_mutex_unlock(&LCKOBJ);
+}
+
+void make_pallet()
+{
+}
+
+FILE* vgs2_fopen(const char* n,const char* p)
+{
+    return fopen(n,p);
+}
+
+void vgs2_showAds()
+{
+}
+
+void vgs2_deleteAds()
+{
+}

--- a/template/vgs2api.c
+++ b/template/vgs2api.c
@@ -424,6 +424,37 @@ int bload(unsigned char n,const char* name)
 
 /*
  *----------------------------------------------------------------------------
+ * load a BGM file (direct)
+ *----------------------------------------------------------------------------
+ */
+int bload_direct(unsigned char n,const char* name)
+{
+	FILE* fp;
+	int size;
+	fp=fopen(name,"rb");
+	if(NULL==fp) {
+		return -1;
+	}
+	fseek(fp,0,SEEK_END);
+	size=ftell(fp);
+	if(size<1) {
+		fclose(fp);
+		return -1;
+	}
+	fseek(fp,0,SEEK_SET);
+	_note[n]=(char*)malloc(size);
+	if(NULL==_note[n]) {
+		fclose(fp);
+		return -1;
+	}
+	fread(_note[n],size,1,fp);
+	fclose(fp);
+    _notelen[n]=(uLong)size;
+	return 0;
+}
+
+/*
+ *----------------------------------------------------------------------------
  * get rom data (INTERNAL FUNCTION)
  *----------------------------------------------------------------------------
  */


### PR DESCRIPTION
VGSのBGMデータを端末エミュレータ（ターミナル）上で再生する `vgs2play` コマンドを追加します。
```bash
$ vgs2play bgm-file
```

なお、Linux または Mac OS X 専用です。

__Windows has deprecated.__

というのは冗談ですが、WindowsだとCLI上でもウィンドウハンドルを渡さないと音声再生ができないんですよね。つまり、Windowsで音声を再生するならGUIで作れと。以前そういうツール作ったっちゃ作ったんですが、さっぱりメンテしてないなー。（GUIって操作がまどろっこしいからあまり好きではない）