### PR TITLE
Sr1.07: bugfix ノンインタレースモードだと落ちる(Linux / Mac OS X)

### DIFF
--- a/template/vgs2l.c
+++ b/template/vgs2l.c
@@ -188,10 +188,10 @@ int main(int argc,char* argv[])
 			usleep(100000);
 			continue;
 		}
+		ptr=(unsigned short*)surface->pixels;
+		vp=0;
+		pp=0;
 		if(_interlace) {
-			ptr=(unsigned short*)surface->pixels;
-			vp=0;
-			pp=0;
 			for(vy=0;vy<YSIZE;vy++) {
 				for(vx=0;vx<XSIZE;vx++) {
 					if(_vram.sp[vp]) {

--- a/template/vgs2l.c
+++ b/template/vgs2l.c
@@ -36,7 +36,7 @@ int main(int argc,char* argv[])
 	char path[16];
 	int cn,pn,bn;
 	unsigned short* ptr;
-	int vx,vy,px,py,vp,pp;
+	int vx,vy,vp,pp;
 	unsigned int n;
 	unsigned int ticks;
 	int mx;
@@ -192,8 +192,8 @@ int main(int argc,char* argv[])
 			ptr=(unsigned short*)surface->pixels;
 			vp=0;
 			pp=0;
-			for(vy=0,py=0;vy<YSIZE;vy++,py+=2) {
-				for(vx=0,px=0;vx<XSIZE;vx++,px+=2) {
+			for(vy=0;vy<YSIZE;vy++) {
+				for(vx=0;vx<XSIZE;vx++) {
 					if(_vram.sp[vp]) {
 						ptr[pp]=ADPAL[_vram.sp[vp]];
 						ptr[pp+1]=ADPAL[_vram.sp[vp]];
@@ -212,8 +212,8 @@ int main(int argc,char* argv[])
 				pp+=320;
 			}
 		} else {
-			for(vy=0,py=0;vy<YSIZE;vy++,py+=2) {
-				for(vx=0,px=0;vx<XSIZE;vx++,px+=2) {
+			for(vy=0;vy<YSIZE;vy++) {
+				for(vx=0;vx<XSIZE;vx++) {
 					if(_vram.sp[vp]) {
 						ptr[pp]=ADPAL[_vram.sp[vp]];
 						ptr[pp+1]=ADPAL[_vram.sp[vp]];

--- a/template/vgs2x.c
+++ b/template/vgs2x.c
@@ -36,7 +36,7 @@ int vgs2_main(int argc,char* argv[])
     char path[16];
     int cn,pn,bn;
     unsigned short* ptr;
-    int vx,vy,px,py,vp,pp;
+    int vx,vy,vp,pp;
     unsigned int n;
     unsigned int ticks;
     int mx;
@@ -202,8 +202,8 @@ int vgs2_main(int argc,char* argv[])
             ptr=(unsigned short*)surface->pixels;
             vp=0;
             pp=0;
-            for(vy=0,py=0;vy<YSIZE;vy++,py+=2) {
-                for(vx=0,px=0;vx<XSIZE;vx++,px+=2) {
+            for(vy=0;vy<YSIZE;vy++) {
+                for(vx=0;vx<XSIZE;vx++) {
                     if(_vram.sp[vp]) {
                         ptr[pp]=ADPAL[_vram.sp[vp]];
                         ptr[pp+1]=ADPAL[_vram.sp[vp]];
@@ -222,8 +222,8 @@ int vgs2_main(int argc,char* argv[])
                 pp+=320;
             }
         } else {
-            for(vy=0,py=0;vy<YSIZE;vy++,py+=2) {
-                for(vx=0,px=0;vx<XSIZE;vx++,px+=2) {
+            for(vy=0;vy<YSIZE;vy++) {
+                for(vx=0;vx<XSIZE;vx++) {
                     if(_vram.sp[vp]) {
                         ptr[pp]=ADPAL[_vram.sp[vp]];
                         ptr[pp+1]=ADPAL[_vram.sp[vp]];

--- a/template/vgs2x.c
+++ b/template/vgs2x.c
@@ -198,10 +198,10 @@ int vgs2_main(int argc,char* argv[])
             usleep(100000);
             continue;
         }
+        ptr=(unsigned short*)surface->pixels;
+        vp=0;
+        pp=0;
         if(_interlace) {
-            ptr=(unsigned short*)surface->pixels;
-            vp=0;
-            pp=0;
             for(vy=0;vy<YSIZE;vy++) {
                 for(vx=0;vx<XSIZE;vx++) {
                     if(_vram.sp[vp]) {


### PR DESCRIPTION
Mac OS X版またはLinux版で、ノンインタレースモード（`vgs2_interlace(0)`）にすると、Segmentation Faultでアプリが落ちる問題を修正しました。