### PR TITLE
Sr1.09: Sound does not stop in the background.

### DIFF
--- a/template/vgs2soundw.cpp
+++ b/template/vgs2soundw.cpp
@@ -108,6 +108,7 @@ extern "C" int init_sound(HWND hWnd)
 	memset(&desc,0,sizeof(desc));
 	desc.dwSize=(DWORD)sizeof(desc);
 	desc.dwFlags=DSBCAPS_CTRLPOSITIONNOTIFY;
+	desc.dwFlags|=DSBCAPS_GLOBALFOCUS;
 	desc.dwBufferBytes=SAMPLE_BUFS;
 	desc.lpwfxFormat=&wFmt;
 	desc.guid3DAlgorithm=GUID_NULL;


### PR DESCRIPTION
Windows版のVGSでウインドウがバックグラウンドに遷移しても音を止めないようにする仕様変更を実施。