### PR TITLE
Sr1.13: support meta data

### DIFF
--- a/bin_src/.clang-format
+++ b/bin_src/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle:  Google
+ColumnLimit: 160
+IndentWidth: 4
+BreakBeforeBraces: Linux
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+AllowShortFunctionsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+

--- a/bin_src/makefile
+++ b/bin_src/makefile
@@ -13,6 +13,7 @@ allcom: ../bin\
 	../bin/vgs2mml\
 	../bin/vgs2rom\
 	../bin/vgs2wav\
+	../bin/vgs2pack\
 	../bin/vgs2play
 
 ../bin:
@@ -32,6 +33,9 @@ allcom: ../bin\
 
 ../bin/vgs2wav: vgs2wav.c
 	gcc -o ../bin/vgs2wav vgs2wav.c
+
+../bin/vgs2pack: vgs2pack.c vgs2pack.h ../template/vgs2api.c ../template/vgs2.h
+	gcc -o ../bin/vgs2pack -I../template vgs2pack.c ../template/vgs2sound.c ../template/vgs2api.c ../template/vgs2tone.c $(SOUNDLIB) -lpthread
 
 ../bin/vgs2play: vgs2play.c ../template/vgs2sound.c ../template/vgs2api.c ../template/vgs2tone.c ../template/vgs2.h
 	gcc -o ../bin/vgs2play -I../template vgs2play.c ../template/vgs2sound.c ../template/vgs2api.c ../template/vgs2tone.c $(SOUNDLIB) -lpthread

--- a/bin_src/makefile.win
+++ b/bin_src/makefile.win
@@ -5,6 +5,7 @@ all:\
 	..\bin\vgs2bmp.exe \
 	..\bin\vgs2mkpj.exe \
 	..\bin\vgs2rom.exe \
+	..\bin\vgs2pack.exe \
 	..\bin\vgs2wav.exe
 
 clean:
@@ -19,6 +20,8 @@ clean:
 	-@del vgs2wav.exe
 	-@del vgs2mml.obj
 	-@del vgs2mml.exe
+	-@del vgs2pack.obj
+	-@del vgs2pack.exe
 
 ..\bin:
 	mkdir ..\bin
@@ -46,6 +49,11 @@ T=vgs2wav
 T=vgs2mml
 ..\bin\$(T).exe: $(T).c
 	CL /MT $(T).c
+	copy $(T).exe ..\bin\$(T).exe
+
+T=vgs2pack
+..\bin\$(T).exe: $(T).c vgs2pack.h ../template/vgs2soundw.cpp ../template/vgs2api.c ../template/vgs2tone.c ../template/vgs2.h
+	CL /I../template /MT $(T).c ../template/vgs2soundw.cpp ../template/vgs2api.c ../template/vgs2tone.c dxguid.lib dsound.lib user32.lib
 	copy $(T).exe ..\bin\$(T).exe
 
 T=vgs2play

--- a/bin_src/vgs2pack.c
+++ b/bin_src/vgs2pack.c
@@ -1,0 +1,219 @@
+#ifdef __WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "vgs2pack.h"
+#include "vgs2.h"
+
+int bload_direct(unsigned char n, const char* name);
+extern struct _PSG _psg;
+
+static int getInfoNum(FILE* fp);
+static int cpy(char* to, size_t size, char* from, int line);
+static void trimstring(char* src);
+
+int main(int argc, char* argv[])
+{
+    struct VgsMetaHeader head;
+    struct VgsMetaData data;
+    char buf[4096];
+    FILE* bgm = NULL;
+    FILE* meta = NULL;
+    FILE* pack = NULL;
+    size_t len;
+    char* cp;
+    int st = 0;
+    int line = 0;
+    int size;
+
+    int result = 1;
+
+    if (argc < 2) {
+        puts("vgs2pack base-filename");
+        puts("- input(1): {base-filename}.BGM");
+        puts("- input(2): {base-filename}.meta");
+        puts("- output: {base-filename}.vgs");
+        goto ENDPROC;
+    }
+
+    if (NULL != (cp = strchr(argv[1], '.'))) *cp = '\0';
+
+    sprintf(buf, "%s.BGM", argv[1]);
+    if (NULL == (bgm = fopen(buf, "rb"))) {
+        puts("BGM file not found.");
+        goto ENDPROC;
+    }
+    if (bload_direct(0, buf)) {
+        puts("Could not read the BGM file.");
+        goto ENDPROC;
+    }
+
+    sprintf(buf, "%s.meta", argv[1]);
+    if (NULL == (meta = fopen(buf, "rt"))) {
+        puts("meta file not found.");
+        goto ENDPROC;
+    }
+
+    sprintf(buf, "%s.vgs", argv[1]);
+    if (NULL == (pack = fopen(buf, "wb"))) {
+        puts("meta file not found.");
+        goto ENDPROC;
+    }
+
+    memset(&head, 0, sizeof(head));
+    memset(&data, 0, sizeof(data));
+    memset(&buf, 0, sizeof(buf));
+
+    if (0 == (head.num = (unsigned char)(getInfoNum(meta) & 0xff))) {
+        puts("meta file has no \"Data:\".");
+        goto ENDPROC;
+    }
+
+    head.secIi = htons((unsigned short)(_psg.timeI / 22050));
+    head.secIf = htons((unsigned short)(_psg.timeI % 22050 * 0.0453514739229));
+    if (999 < head.secIf) head.secIf = 999;
+    head.secLi = htons((unsigned short)(_psg.timeL / 22050));
+    head.secLf = htons((unsigned short)(_psg.timeL % 22050 * 0.0453514739229));
+    if (999 < head.secLf) head.secLf = 999;
+
+    strcpy(head.eyecatch, "VGSPACK");
+
+    while (fgets(buf, sizeof(buf) - 1, meta)) {
+        line++;
+        if (NULL != (cp = strchr(buf, '\r'))) *cp = '\0';
+        if (NULL != (cp = strchr(buf, '\n'))) *cp = '\0';
+        trimstring(buf);
+        if ('#' == buf[0]) continue;
+        len = strlen(buf);
+        if (len < 1) continue;
+        if (strcmp("Data:", buf) == 0) {
+            if (0 == st)
+                fwrite(&head, 1, sizeof(head), pack);
+            else
+                fwrite(&data, 1, sizeof(data), pack);
+            memset(&data, 0, sizeof(data));
+            st++;
+            continue;
+        }
+        cp = strchr(buf, '=');
+        if (NULL == cp) continue;
+        *cp = '\0';
+        cp++;
+        trimstring(buf);
+        trimstring(cp);
+        if (0 == st) {
+            if (strcmp(buf, "format") == 0) {
+                if (cpy(head.format, sizeof(head.format), cp, line)) goto ENDPROC;
+            } else if (strcmp(buf, "genre") == 0) {
+                if (cpy(head.genre, sizeof(head.genre), cp, line)) goto ENDPROC;
+            } else {
+                printf("Error: unknown parameter \"%s\" (line=%d)\n", buf, line);
+                goto ENDPROC;
+            }
+        } else {
+            if (strcmp(buf, "year") == 0) {
+                data.year = htons((unsigned short)atoi(cp));
+            } else if (strcmp(buf, "aid") == 0) {
+                data.aid = htons((unsigned short)atoi(cp));
+            } else if (strcmp(buf, "track") == 0) {
+                data.track = htons((unsigned short)atoi(cp));
+            } else if (strcmp(buf, "album") == 0) {
+                if (cpy(data.album, sizeof(data.album), cp, line)) goto ENDPROC;
+            } else if (strcmp(buf, "song") == 0) {
+                if (cpy(data.song, sizeof(data.song), cp, line)) goto ENDPROC;
+            } else if (strcmp(buf, "team") == 0) {
+                if (cpy(data.team, sizeof(data.team), cp, line)) goto ENDPROC;
+            } else if (strcmp(buf, "creator") == 0) {
+                if (cpy(data.creator, sizeof(data.creator), cp, line)) goto ENDPROC;
+            } else if (strcmp(buf, "right") == 0) {
+                if (cpy(data.right, sizeof(data.right), cp, line)) goto ENDPROC;
+            } else if (strcmp(buf, "code") == 0) {
+                if (cpy(data.code, sizeof(data.code), cp, line)) goto ENDPROC;
+            } else {
+                printf("Error: unknown parameter \"%s\" (line=%d)\n", buf, line);
+                goto ENDPROC;
+            }
+        }
+    }
+    fwrite(&data, 1, sizeof(data), pack);
+
+    while (0 < (size = fread(buf, 1, sizeof(buf), bgm))) {
+        fwrite(buf, size, 1, pack);
+    }
+
+    result = 0;
+ENDPROC:
+    if (bgm) fclose(bgm);
+    if (meta) fclose(meta);
+    if (pack) fclose(pack);
+    return result;
+}
+
+static int getInfoNum(FILE* fp)
+{
+    char buf[4096];
+    char* cp;
+    int n = 0;
+    memset(buf, 0, sizeof(buf));
+    while (fgets(buf, sizeof(buf) - 1, fp)) {
+        if (NULL != (cp = strchr(buf, '\r'))) *cp = '\0';
+        if (NULL != (cp = strchr(buf, '\n'))) *cp = '\0';
+        trimstring(buf);
+        if (strcmp("Data:", buf) == 0) n++;
+    }
+    fseek(fp, 0, SEEK_SET);
+    return n;
+}
+
+static int cpy(char* to, size_t size, char* from, int line)
+{
+    if (size - 1 < strlen(from)) {
+        printf("Error: length over (line=%d)\n", line);
+        return -1;
+    }
+    strcpy(to, from);
+    return 0;
+}
+
+static void trimstring(char* src)
+{
+    int i, j;
+    int len;
+    for (i = 0; ' ' == src[i]; i++)
+        ;
+    if (i) {
+        for (j = 0; src[i] != '\0'; j++, i++) {
+            src[j] = src[i];
+        }
+        src[j] = '\0';
+    }
+    for (len = (int)strlen(src) - 1; 0 <= len && ' ' == src[len]; len--) {
+        src[len] = '\0';
+    }
+}
+
+void putlog(const char* fn, int ln, const char* msg, ...)
+{
+}
+
+void make_pallet()
+{
+}
+
+FILE* vgs2_fopen(const char* n, const char* p)
+{
+    return fopen(n, p);
+}
+
+void vgs2_showAds()
+{
+}
+
+void vgs2_deleteAds()
+{
+}

--- a/bin_src/vgs2pack.h
+++ b/bin_src/vgs2pack.h
@@ -1,0 +1,30 @@
+#ifndef INCLUDE_VGS2PACK_H
+#define INCLUDE_VGS2PACK_H
+
+struct VgsMetaHeader {
+    char eyecatch[8];
+    char format[8];
+    char genre[32];
+    unsigned char num;
+    unsigned char reserved1[3];
+    unsigned short secIi;
+    unsigned short secIf;
+    unsigned short secLi;
+    unsigned short secLf;
+    unsigned int reserved2;
+};
+
+struct VgsMetaData {
+    unsigned short year;
+    unsigned short aid;
+    unsigned short track;
+    unsigned short reserved;
+    char album[56];
+    char song[64];
+    char team[32];
+    char creator[32];
+    char right[32];
+    char code[32];
+};
+
+#endif


### PR DESCRIPTION
VGSのBGMファイルにメタデータを付加できるようにしました。

メタデータのコンテキストは次の通り。
```
struct VgsMetaHeader {
    char eyecatch[8];
    char format[8];
    char genre[32];
    unsigned char num;
    unsigned char reserved1[3];
    unsigned short secIi;
    unsigned short secIf;
    unsigned short secLi;
    unsigned short secLf;
    unsigned int reserved2;
};

struct VgsMetaData {
    unsigned short year;
    unsigned short aid;
    unsigned short track;
    unsigned short reserved;
    char album[56];
    char song[64];
    char team[32];
    char creator[32];
    char right[32];
    char code[32];
};
```

1つのBGMファイルは、必ず __1つヘッダ__ と __1つ以上のデータ__ を持ちます。
通常はデータは1つです。
二次創作ならデータは2つです。

例えば、東方BGM on VGSの楽曲ならメタデータは下記のように定義します。
```
format = VGS1.0
genre = Game Music

Data:
year = 2004
aid = 128
track = 4
album = 東方永夜抄　〜 Imperishable Night.
song = 夜雀の歌声　〜 Night Bird
team = 上海アリス幻樂団
creator = ZUN

Data:
year = 2013
track = 41
album = 東方BGM on VGS
team = SUZUKI PLAN
creator = Yoji Suzuki
right = 東方Project二次創作
```

`vgs2pack` コマンドは、このメタデータが先頭に付与されたBGMファイルです。